### PR TITLE
Handle new and old style docker-machine inspect output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,13 @@
+GOOS="darwin"
+# GOOS="linux"
+# GOOS="windows"
+GOARCH="amd64"
+
 build:
-	$(eval VERSION := $(shell godep go run *.go --version))
-
-	# GOOS=linux GOARCH=amd64 godep go build -o build/docker-rsync.v$(VERSION).linux.x86_64
-	# (cd build && tar -cvzf docker-rsync.v$(VERSION).linux.x86_64.tar.gz docker-rsync.v$(VERSION).linux.x86_64)
-	# rm build/docker-rsync.v$(VERSION).linux.x86_64
-
-	GOOS=darwin GOARCH=amd64 godep go build -o build/docker-rsync.v$(VERSION).darwin.x86_64
-	(cd build && tar -cvzf docker-rsync.v$(VERSION).darwin.x86_64.tar.gz docker-rsync.v$(VERSION).darwin.x86_64)
-	rm build/docker-rsync.v$(VERSION).darwin.x86_64
-
-	# TODO returns error: docker/docker/pkg/term/term.go:16: undefined: Termios
-	# GOOS=windows GOARCH=amd64 godep go build -o build/docker-rsync.v$(VERSION).windows.x86_64
-	# cd build && tar -cvzf docker-rsync.v$(VERSION).windows.x86_64.tar.gz docker-rsync.v$(VERSION).windows.x86_64)
-	# rm build/docker-rsync.v$(VERSION).windows.x86_64
+	GOOS=$(GOOS) GOARCH=$(GOARCH) godep go build -o build/docker-rsync
+	cp build/docker-rsync build/docker-rsync.v`./build/docker-rsync --version`.$(GOOS).$(GOARCH)
+	(cd build && tar -cvzf docker-rsync.v`./docker-rsync -version`.$(GOOS).$(GOARCH).tar.gz docker-rsync.v`./docker-rsync -version`.$(GOOS).$(GOARCH))
+	rm ./build/*.$(GOARCH) ./build/docker-rsync
 
 clean:
 	rm -r build/*

--- a/dockermachine.go
+++ b/dockermachine.go
@@ -40,14 +40,26 @@ func GetSSHPort(machineName string) (port uint, err error) {
 		return 0, err
 	}
 
+	return PortFromMachineJSON(out)
+}
+
+func PortFromMachineJSON(jsonData []byte) (port uint, err error) {
 	var v struct {
 		Driver struct {
+			Driver struct {
+				SSHPort uint
+			}
 			SSHPort uint
 		}
 	}
 
-	if err := json.Unmarshal(out, &v); err != nil {
+	if err := json.Unmarshal(jsonData, &v); err != nil {
 		return 0, err
 	}
-	return v.Driver.SSHPort, nil
+
+	if v.Driver.SSHPort == 0 {
+		return v.Driver.Driver.SSHPort, nil
+	} else {
+		return v.Driver.SSHPort, nil
+	}
 }

--- a/dockermachine_test.go
+++ b/dockermachine_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestPortFromMachineJSONOldStyle(t *testing.T) {
+    const jsonData string = `
+        {
+            "Driver": {
+                "SSHPort": 52435
+            }
+        }
+    `
+    out, _ := PortFromMachineJSON([]byte(jsonData))
+    if out != 52435 {
+        t.Errorf("Expecting 52435 and got %d", out)
+    }
+}
+
+func TestPortFromMachineJSONNewStyle(t *testing.T) {
+    const jsonData string = `
+        {
+            "Driver": {
+                "Driver": {
+                    "SSHPort": 52435
+                }
+            }
+        }
+    `
+    out, _ := PortFromMachineJSON([]byte(jsonData))
+    if out != 52435 {
+        t.Errorf("Expecting 52435 and got %d", out)
+    }
+}


### PR DESCRIPTION
Docker-machine appears to have changed the output format of `docker-machine inspect {machine}`. They did this without changing the `ConfigVersion`, which feels fairly wrong. This should allow the parsing to work in either case.