### PR TITLE
Only provision when necessary (boot2docker is getting these packages)

### DIFF
--- a/dockermachine.go
+++ b/dockermachine.go
@@ -7,22 +7,41 @@ import (
 	"os/exec"
 )
 
-func Provision(machineName string, verbose bool) {
-	c := []string{
-		// install and run rsync daemon
-		`tce-load -wi rsync attr acl`,
-
-		// disable boot2dockers builtin vboxfs
-		// TODO bad idea, because you then can't use vboxfs anymore
-		// `sudo umount /Users || /bin/true`,
+func needsProvisioning(machineName string, verbose bool) bool {
+	checkCommands := []string{
+		`which rsync attr`,
 	}
 
-	for _, v := range c {
-		out, err := RunSSHCommand(machineName, v, verbose)
-		if err != nil {
-			fmt.Println(err)
-			fmt.Printf("%s\n", out)
-			os.Exit(1)
+	for _, command := range checkCommands {
+		if _, err := RunSSHCommand(machineName, command, verbose); err != nil {
+			if verbose {
+				fmt.Println("Provisioning the docker-machine")
+			}
+			return true
+		}
+	}
+
+	return false
+}
+
+func Provision(machineName string, verbose bool) {
+	if needsProvisioning(machineName, verbose) {
+		c := []string{
+			// install and run rsync daemon
+			`tce-load -wi rsync attr acl`,
+
+			// disable boot2dockers builtin vboxfs
+			// TODO bad idea, because you then can't use vboxfs anymore
+			// `sudo umount /Users || /bin/true`,
+		}
+
+		for _, v := range c {
+			out, err := RunSSHCommand(machineName, v, verbose)
+			if err != nil {
+				fmt.Println(err)
+				fmt.Printf("%s\n", out)
+				os.Exit(1)
+			}
 		}
 	}
 }


### PR DESCRIPTION
The rsync, attr, and acl packages are going to be included in the next boot2docker release. https://github.com/boot2docker/boot2docker/pull/1103