### PR TITLE
Use information from docker-machine inspect for rsync SSH

### DIFF
--- a/dockermachine.go
+++ b/dockermachine.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 )
 
 func Provision(machineName string, verbose bool) {
@@ -31,11 +30,11 @@ func RunSSHCommand(machineName, command string, verbose bool) (out []byte, err e
 	if verbose {
 		fmt.Println(`docker-machine ssh ` + machineName + ` '` + command + `'`)
 	}
-	return exec.Command("/bin/sh", "-c", `docker-machine ssh `+machineName+` '`+command+`'`).CombinedOutput()
+	return Exec("docker-machine", "ssh", machineName, command).CombinedOutput()
 }
 
 func GetSSHPort(machineName string) (port uint, err error) {
-	out, err := exec.Command("/bin/sh", "-c", `docker-machine inspect `+machineName).CombinedOutput()
+	out, err := Exec("docker-machine", "inspect", machineName).CombinedOutput()
 	if err != nil {
 		return 0, err
 	}

--- a/exec.go
+++ b/exec.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func Exec(cmd string, args ...string) *exec.Cmd {
+	shCmd := fmt.Sprintf("%s %s", cmd, strings.Join(args, " "))
+	a := []string{"-c", shCmd}
+
+	return exec.Command("/bin/sh", a...)
+}

--- a/exec_windows.go
+++ b/exec_windows.go
@@ -1,0 +1,16 @@
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func Exec(cmd string, args ...string) *exec.Cmd {
+	shCmd := fmt.Sprintf("%s %s", cmd, strings.Join(args, " "))
+	a := []string{"-Command", shCmd}
+
+	return exec.Command("powershell", a...)
+}

--- a/main.go
+++ b/main.go
@@ -62,12 +62,12 @@ func main() {
 		rsyncEndpoint := via
 
 		fmt.Printf("Syncing %s (local) to %s (%s)\n", *srcpath, *dstpath, rsyncEndpoint)
-		Sync(rsyncEndpoint, 0, rpath, rpathDir, *verbose) // initial sync
+		Sync(rsyncEndpoint, SSHCredentials{}, rpath, rpathDir, *verbose) // initial sync
 
 		if *watch {
 			fmt.Println("Watching for file changes ...")
 			Watch(rpath, func(id uint64, path string, flags []string) {
-				Sync(rsyncEndpoint, 0, rpath, rpathDir, true)
+				Sync(rsyncEndpoint, SSHCredentials{}, rpath, rpathDir, true)
 			})
 		}
 
@@ -75,7 +75,7 @@ func main() {
 		// use rsync via ssh
 		machineName := via
 
-		port, err := GetSSHPort(machineName)
+		c, err := GetSSHCredentials(machineName)
 		if err != nil {
 			fmt.Printf("error: unable to get port for machine '%v': %v\n", machineName, err)
 			os.Exit(1)
@@ -84,12 +84,12 @@ func main() {
 		Provision(machineName, *verbose)
 		RunSSHCommand(machineName, "sudo mkdir -p "+rpathDir, *verbose)
 		fmt.Printf("Syncing %s (local) to %s (docker-machine %s)\n", *srcpath, *dstpath, machineName)
-		Sync(machineName, port, rpath, rpathDir, *verbose) // initial sync
+		Sync(machineName, c, rpath, rpathDir, *verbose) // initial sync
 
 		if *watch {
 			fmt.Println("Watching for file changes ...")
 			Watch(rpath, func(id uint64, path string, flags []string) {
-				Sync(machineName, port, rpath, rpathDir, true)
+				Sync(machineName, c, rpath, rpathDir, true)
 			})
 		}
 	}

--- a/rsync.go
+++ b/rsync.go
@@ -9,7 +9,7 @@ import (
 
 var lastSyncError = ""
 
-func Sync(via string, port uint, src, dst string, verbose bool) {
+func Sync(via string, c SSHCredentials, src, dst string, verbose bool) {
 	args := []string{
 		// "--verbose",
 		// "--stats",
@@ -33,11 +33,9 @@ func Sync(via string, port uint, src, dst string, verbose bool) {
 		args = append(args, filepath.Join(src)+"/.")
 		args = append(args, via)
 	} else {
-		machineName := via
-		homePath := os.Getenv("HOME")
-		args = append(args, fmt.Sprintf(`-e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=quiet -i "%s" -p %v'`, filepath.Join(homePath, "/.docker/machine/machines", machineName, "id_rsa"), port))
+		args = append(args, fmt.Sprintf(`-e 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=quiet -i "%s" -p %v'`, c.SSHKeyPath, c.SSHPort))
 		args = append(args, "--rsync-path='sudo rsync'")
-		args = append(args, src, "docker@localhost:"+dst)
+		args = append(args, src, fmt.Sprintf("%s@%s:%s", c.SSHUser, c.IPAddress, dst))
 	}
 
 	cmd := Exec("rsync", args...)

--- a/rsync.go
+++ b/rsync.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -41,10 +40,7 @@ func Sync(via string, port uint, src, dst string, verbose bool) {
 		args = append(args, src, "docker@localhost:"+dst)
 	}
 
-	command := "rsync " + strings.Join(args, " ")
-
-	// fmt.Println("/bin/sh", "-c", command)
-	cmd := exec.Command("/bin/sh", "-c", command)
+	cmd := Exec("rsync", args...)
 
 	if verbose {
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
Use the information on docker-machine inspect for the SSH information for rsync. This allows for you to use docker-rsync to sync non-local docker-machine machines.