### PR TITLE
[FIX] add latest version of fsnotify/fsevents

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/mattes/fsevents"
+	"github.com/fsnotify/fsevents"
 	"sort"
 	"time"
 )


### PR DESCRIPTION
This PR is suppose to fix docker-rsync for Go 1.6 https://github.com/synack/docker-rsync/issues/16