### PR TITLE
Update event handler to use expected unbuffered Events chan

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -41,9 +41,8 @@ func Watch(path string, eventHandler func(id uint64, path string, flags []string
 	es.Start()
 	ec := es.Events
 
-	for {
-		select {
-		case event := <-ec:
+	for msg := range ec {
+		for _, event := range msg {
 			flags := make([]string, 0)
 			for bit, description := range noteDescription {
 				if event.Flags&bit == bit {
@@ -53,7 +52,6 @@ func Watch(path string, eventHandler func(id uint64, path string, flags []string
 			sort.Sort(sort.StringSlice(flags))
 			go eventHandler(event.ID, event.Path, flags)
 
-			es.Flush(false)
 		}
 	}
 }


### PR DESCRIPTION
This updates the Watch eventHandler to account for the unbuffered Events chan, which is used in the latest fsnotify/fsevents https://github.com/synack/docker-rsync/pull/19. This fix resolved https://github.com/synack/docker-rsync/issues/20

I also removed the `Flush` call, as there was mention in https://github.com/fsnotify/fsevents/pull/8 that FSEvents should be handling buffering itself. I didn't find any issues with removing it, but then again I'm not sure what the conditions were to trigger it.