### PR TITLE
Add -guestport for supporting custom port with docker-machine generic driver.

### DIFF
--- a/dockermachine.go
+++ b/dockermachine.go
@@ -60,20 +60,20 @@ func RunSSHCommand(machineName, command string, verbose bool) (out []byte, err e
 	return Exec("docker-machine", "ssh", machineName, command).CombinedOutput()
 }
 
-func GetSSHCredentials(machineName string) (creds SSHCredentials, err error) {
+func GetSSHCredentials(machineName string, guestport uint) (creds SSHCredentials, err error) {
 	out, err := Exec("docker-machine", "inspect", "--format='{{json .Driver}}'", machineName).CombinedOutput()
 	if err != nil {
 		return SSHCredentials{}, err
 	}
 
-	return CredentialsFromMachineJSON(out)
+	return CredentialsFromMachineJSON(out, guestport)
 }
 
-func CredentialsFromMachineJSON(jsonData []byte) (creds SSHCredentials, err error) {
+func CredentialsFromMachineJSON(jsonData []byte, guestport uint) (creds SSHCredentials, err error) {
 	var v SSHCredentials
 	if err := json.Unmarshal(jsonData, &v); err != nil {
 		return SSHCredentials{}, err
 	}
-	v.SSHGuestPort = uint(22) // assume that this is the default SSH port
+	v.SSHGuestPort = uint(guestport)
 	return v, nil
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 	var verbose = flag.Bool("verbose", false, "Verbose output")
 	var srcpath = flag.String("src", pwd, "Source directory")
 	var dstpath = flag.String("dst", pathpkg.Join("/rsync", pwd), "Destination directory")
+        var guestport = flag.Uint("guestport", 22, "SSH Guest Port for docker-machine")
 
 	flag.Parse()
 
@@ -75,7 +76,7 @@ func main() {
 		// use rsync via ssh
 		machineName := via
 
-		c, err := GetSSHCredentials(machineName)
+		c, err := GetSSHCredentials(machineName, *guestport)
 		if err != nil {
 			fmt.Printf("error: unable to get port for machine '%v': %v\n", machineName, err)
 			os.Exit(1)


### PR DESCRIPTION
Add -guestport for supporting custom port with docker-machine generic driver.

Please review this and Thanks for this awesome tool.

Signed-off-by: Minho Ryang minhoryang@gmail.com
